### PR TITLE
Fix for GHA fail per Deploy job

### DIFF
--- a/.github/workflows/render-specs.yml
+++ b/.github/workflows/render-specs.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-deploy-spec:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.


### PR DESCRIPTION
Signed-off-by: Stephen Curran <swcurran@gmail.com>

The publish job is failing with:

```
/usr/bin/git push origin --force gh-pages
  remote: Permission to dhh1128/did-method-webs.git denied to github-actions[bot].
  fatal: unable to access 'https://github.com/dhh1128/did-method-webs.git/': The requested URL returned error: 403
  Error: Action failed with "The process '/usr/bin/git' failed with exit code 128"
```

Per [this](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-first-deployment-with-github_token), this PR should fix it.