### PR TITLE
fix gh-pages rendering

### DIFF
--- a/.github/workflows/render-specs.yml
+++ b/.github/workflows/render-specs.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build-and-deploy-spec:
@@ -13,23 +14,29 @@ jobs:
       contents: write
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
-        with:
-          persist-credentials: false
+        uses: actions/checkout@v4
 
-      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
-        run: |
-          npm install
-          node -e "require('./index')({ nowatch: true })"
-          rm -rf node_modules
+      - name: Setup Node.js 📦
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Dependencies 📥
+        run: npm ci
+
+      - name: Build Specification 🔧
+        run: npm run menu 4
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3.7.3
+        uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
           publish_dir: ./docs/
           allow_empty_commit: true
           force_orphan: true
-
-
-          
+          commit_message: "Render specs and deploy to GitHub Pages [skip ci]"
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"
+      


### PR DESCRIPTION
`./index.ts` ran the old way of rendering the spec, now we use Spec-Up-T with `npm run render`. This fixes that for the CI build to GitHub Pages.