### PR TITLE
fix github references after name change to kswg

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "Nuttawut Kongsuwan <nuttawut@finema.co> (https://finema.co)",
     "Sam Smith <sam@prosapien.com> (https://prosapien.com)"
   ],
-  "homepage": "https://github.com/trustoverip/tswg-did-method-webs-specification#readme",
+  "homepage": "https://github.com/trustoverip/kswg-did-method-webs-specification#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/trustoverip/tswg-did-method-webs-specification.git",
+    "url": "git+https://github.com/trustoverip/kswg-did-method-webs-specification.git",
     "directory": "."
   },
   "bugs": {
-    "url": "https://github.com/trustoverip/tswg-did-method-webs-specification/issues"
+    "url": "https://github.com/trustoverip/kswg-did-method-webs-specification/issues"
   },
   "keywords": [
     "keri",

--- a/spec/body.md
+++ b/spec/body.md
@@ -2545,7 +2545,7 @@ support, delegated identifier support for signing scalability, and the
 creation of [[ref: pre-rotated]] keys to prevent loss of control of the
 identifier if the current private key were to be compromised.
 You may find the
-[did:webs feature dependency diagram](https://github.com/trustoverip/tswg-did-method-webs-specification/blob/main/WEBS_FEATURE_DEPS.md)
+[did:webs feature dependency diagram](https://github.com/trustoverip/kswg-did-method-webs-specification/blob/main/WEBS_FEATURE_DEPS.md)
 helpful as a visual guide to the features and dependencies of `did:webs`.
 :::
 
@@ -2896,7 +2896,7 @@ events.
 cryptographic keys, identifiers, and associated verifiable data structures.
 KERI was first described in an
 [academic paper](https://arxiv.org/abs/1907.02143), and its
-[specification](https://github.com/trustoverip/tswg-keri-specification) is
+[specification](https://github.com/trustoverip/kswg-keri-specification) is
 currently incubated under [Trust Over IP Foundation](https://trustoverip.org/).
 The open source community that develops KERI-related technologies can be
 found at `https://github.com/WebOfTrust/keri`. This section outlines the

--- a/spec/header.md
+++ b/spec/header.md
@@ -10,9 +10,9 @@ we encourage additional did:webs implementations to the original
 
 **Latest Draft:**
 
-[https://github.com/trustoverip/tswg-did-method-webs-specification][tswg-gh]
+[https://github.com/trustoverip/kswg-did-method-webs-specification][kswg-gh]
 
-[tswg-gh]: https://github.com/trustoverip/tswg-did-method-webs-specification
+[kswg-gh]: https://github.com/trustoverip/kswg-did-method-webs-specification
 
 **Editors:**
 
@@ -36,8 +36,8 @@ we encourage additional did:webs implementations to the original
 
 **Participate:**
 
-~ [GitHub repo](https://github.com/trustoverip/tswg-did-method-webs-specification)
-~ [Commit history](https://github.com/trustoverip/tswg-did-method-webs-specification/commits/main)
+~ [GitHub repo](https://github.com/trustoverip/kswg-did-method-webs-specification)
+~ [Commit history](https://github.com/trustoverip/kswg-did-method-webs-specification/commits/main)
 
 [msabadello]: https://www.linkedin.com/in/markus-sabadello-353a0821/
 
@@ -102,7 +102,7 @@ did:webs:example.com%3A3000:users:alice:EKYGGh-FtAphGmSZbsuBs_t4qpsjYJ2ZqvMKluq9
 
 Information about the current status of this document, any errata,
 and how to provide feedback on it, may be obtained at
-[https://github.com/trustoverip/tswg-did-method-webs-specification](https://github.com/trustoverip/tswg-did-method-webs-specification).
+[https://github.com/trustoverip/kswg-did-method-webs-specification](https://github.com/trustoverip/kswg-did-method-webs-specification).
 
 ## Copyright Notice
 

--- a/specs.json
+++ b/specs.json
@@ -10,12 +10,12 @@
         "body.md"
       ],
       "logo": "https://raw.githubusercontent.com/trustoverip/logo-assets/master/logos/ToIP-Logo-Color-SolidDimensional-Horizontal-LightOnDark.svg",
-      "logo_link": "https://github.com/trustoverip/tswg-did-method-webs-specification",
+      "logo_link": "https://github.com/trustoverip/kswg-did-method-webs-specification",
       "katex": true,
       "source": {
         "host": "github",
         "account": "trustoverip",
-        "repo": "tswg-did-method-webs-specification"
+        "repo": "kswg-did-method-webs-specification"
       },
       "author": "Trust over IP Foundation",
       "description": "Create technical specifications in markdown. Based on the original Spec-Up, extended with Terminology tooling",


### PR DESCRIPTION
Fix various broken links due to repo name change from `tswg` to `kswg`.