### PR TITLE
Clarify transformation rules language and service endpoint list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "did-webs-spec",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "did-webs-spec",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "dotenv": "^17.3.1",
-        "spec-up-t": "^1.6.19"
+        "spec-up-t": "^1.6.20"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -4597,9 +4597,9 @@
       }
     },
     "node_modules/spec-up-t": {
-      "version": "1.6.19",
-      "resolved": "https://registry.npmjs.org/spec-up-t/-/spec-up-t-1.6.19.tgz",
-      "integrity": "sha512-tjhK5UtSCGxTYnuHMQ7SyKnbXJElVkbyLMUXPnJ/WfUyABnpK6VGpzLt8+QV3L7arCnHjCWjpnbXx/bhnaRLqg==",
+      "version": "1.6.20",
+      "resolved": "https://registry.npmjs.org/spec-up-t/-/spec-up-t-1.6.20.tgz",
+      "integrity": "sha512-7TOuawdsDEkm62YOO0bWv3SK2DY4bPodi0rv7ANaSO9qaw+k/a9sm1WSU157QDAD3DZF7NtDnQv6kXwqfKerfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@octokit/plugin-throttling": "^9.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "did-webs-spec",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "license": "Apache-2.0",
   "description": "ToIP KSWG did:webs specification written in Markdown and converted to HTML using the Spec-Up-T tool.",
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "dotenv": "^17.3.1",
-    "spec-up-t": "^1.6.19"
+    "spec-up-t": "^1.6.20"
   },
   "overrides": {
     "braces": ">=3.0.3",

--- a/spec/body.md
+++ b/spec/body.md
@@ -969,8 +969,13 @@ This section is normative.
 
 ::: informative Service endpoint mapping and metadata
 For additional details about the mapping between KERI events and the Service
-Endpoints in the DID Document, see
-[Service Endpoint KERI events](#service-endpoint-event-details).
+Endpoints in the DID Document, such as 
+- witness,
+- mailbox,
+- delegator OOBI, and 
+- agent service endpoints, 
+
+see [Service Endpoint KERI events](#service-endpoint-event-details).
 
 It is important to note that DID document service endpoints are different
 than the KERI service endpoints detailed in
@@ -1042,20 +1047,24 @@ at rest and versioned to ensure only the latest signed data is available.
 
 This section is normative.
 
-The DID document that exists as a resource on a webserver is compatible with
-the `did:web` DID method and therefore necessarily different from a
-`did:webs` DID document with regard to the `id`, `controller`, and
-`alsoKnownAs` properties.
+When transforming a `did:webs` DID document to the corresponding `did:web` DID document
+the following rules determine what MUST change to make a valid, transformed `did:web`
+version of the `did:webs` DID document. 
 
-1. To transform the `did:webs` form of the DID Document to a `did:web` the
-   transformation MUST do the following:
-    1. In the values of the top-level `id` and `controller` properties of
-       the DID document, the transformation MUST replace the `did:webs`
-       prefix string with `did:web`.
-    1. In the value of the top-level `alsoKnownAs` property, the
-       transformation MUST replace the entry that is now the new value of the
-       `id` property (using `did:web`) with the old value of the `id`
-       property (using `did:webs`).
+::: informative properties affected by transformation
+This transformation primarily affects 
+the `id` and `controller` properties, and, when authorized with a designated aliases
+ACDC, the `alsoKnownAs` properties.
+:::
+
+1. Transformation of the `did:webs` form of the DID Document to a `did:web` DID document
+   MUST do the following:
+    1. The top-level `id` and `controller` property values of the DID document 
+       MUST replace the `did:webs` prefix string with the `did:web` prefix.
+    1. If authorized by designated alias ACDC, the top-level `alsoKnownAs` property 
+       containing a `did:web` DID MUST replace that `did:web` entry with the 
+       authorized `did:webs` DID corresponding to the old `did:webs` value from
+       the prior `id` and `controller` field values (`did:webs` DID).
     1. All other content of the DID document MUST not be modified.
 
     For example, this transformation is used during the [Create](#create) DID
@@ -1119,18 +1128,24 @@ the `did:web` DID method and therefore necessarily different from a
 
 This section is normative.
 
-This section defines an inverse transformation algorithm from a `did:web`
-DID document to a `did:webs` DID document.
+When transforming a `did:web` DID document to the corresponding `did:webs` 
+DID document the following rules determine what MUST change to make a valid, 
+transformed `did:webs` version of the `did:web` DID document.
 
-1. Given a `did:web` DID document, a transformation to a `did:webs` DID
-   document MUST have the following differences:
-    1. In the values of the top-level `id` and `controller` properties of
-       the DID document, the transformation MUST replace the `did:web`
-       prefix string with `did:webs`.
-    1. The value of the top-level `alsoKnownAs` property MUST replace the
-       entry that is now the new value of the `id` property (using
-       `did:webs`) with the old value of the `id` property (using
-       `did:web`).
+::: informative properties affected by transformation
+This transformation primarily affects
+the `id` and `controller` properties, and, when authorized with a designated 
+aliases ACDC, the `alsoKnownAs` properties.
+:::
+
+1. Transformation of the `did:web` DID document to a `did:webs` DID document 
+   MUST do the following:
+    1. The top-level `id` and `controller` property values of the DID document
+       MUST replace the `did:web` prefix string with the `did:webs` prefix.
+    1. If authorized by designated alias ACDC, the top-level `alsoKnownAs` property
+       containing a `did:webs` DID MUST replace that `did:webs` entry with the
+       authorized `did:web` DID corresponding to the old `did:web` value from
+       the prior `id` and `controller` field values (`did:web` DID).
     1. All other content of the DID document MUST not be modified.
 1. A `did:webs` resolver MUST use this transformation during the
    [Read (Resolve)](#read-resolve) DID method operation.
@@ -1619,6 +1634,49 @@ Resulting mailbox service entry:
 }
 ```
 
+#### Delegator Service Endpoint
+
+If the first event in the [[ref: KEL]] for a `did:webs` DID is a delegated
+inception event of type `dip` then it MUST include a delegator service
+endpoint in its DID document as follows.
+
+1. A delegated AID MUST include a service endpoint in its DID document that
+   references its delegator.
+1. When a delegator service endpoint is present, it MUST conform to the
+   following requirements:
+    1. The service `type` property MUST be set to `DelegatorOOBI`.
+    1. The service `id` property MUST be the [[ref: self-addressing identifier]]
+       ([[ref: SAID]]) of the seal (anchor
+       block) in the delegator's [[ref: KEL]] that commits to the delegate's
+       delegated inception event.
+    1. The service `serviceEndpoint` property MUST be a valid
+       [[ref: out-of-band introduction]] ([[ref: OOBI]]) URL that resolves to
+       the delegator's AID.
+1. The delegator service endpoint enables [[ref: verifiers]] to discover and validate
+   the delegation relationship by retrieving the delegator's [[ref: KEL]].
+
+For example, a `did:webs` DID that is a delegated AID MUST include, in its
+`service` array of the DID document, a delegator service endpoint similar
+to the following:
+
+```json
+{
+  "service": [{
+    "id": "EDEvmKvGFjuip-J5dDw7sbVHxXA22s-pBO764CivsFt4",
+    "type": "DelegatorOOBI",
+    "serviceEndpoint": "http://keria:3902/oobi/ENro7uf0ePmiK3jdTo2YCdXLqW7z7xoP6qhhBou6gBLe"
+  }]
+}
+```
+
+::: informative Delegator endpoint example explanation
+In this example, the `id` field contains the [[ref: SAID]] of the seal in the
+delegator's [[ref: KEL]] that anchors the delegation commitment, and the
+`serviceEndpoint` provides the [[ref: OOBI]] URL to retrieve the delegator's
+key state so that the delegator's KEL may be searched for the delegation
+seal referred to by the `id` property.
+:::
+
 #### Agent Service Endpoint
 
 1. An agent service endpoint is produced when (1) an Endpoint Role
@@ -1675,49 +1733,6 @@ Resulting agent service entry:
   }
 }
 ```
-
-#### Delegator Service Endpoint
-
-If the first event in the [[ref: KEL]] for a `did:webs` DID is a delegated
-inception event of type `dip` then it MUST include a delegator service
-endpoint in its DID document as follows.
-
-1. A delegated AID MUST include a service endpoint in its DID document that
-   references its delegator.
-1. When a delegator service endpoint is present, it MUST conform to the
-   following requirements:
-    1. The service `type` property MUST be set to `DelegatorOOBI`.
-    1. The service `id` property MUST be the [[ref: self-addressing identifier]]
-       ([[ref: SAID]]) of the seal (anchor
-       block) in the delegator's [[ref: KEL]] that commits to the delegate's
-       delegated inception event.
-    1. The service `serviceEndpoint` property MUST be a valid
-       [[ref: out-of-band introduction]] ([[ref: OOBI]]) URL that resolves to
-       the delegator's AID.
-1. The delegator service endpoint enables [[ref: verifiers]] to discover and validate
-   the delegation relationship by retrieving the delegator's [[ref: KEL]].
-
-For example, a `did:webs` DID that is a delegated AID MUST include, in its
-`service` array of the DID document, a delegator service endpoint similar
-to the following:
-
-```json
-{
-  "service": [{
-    "id": "EDEvmKvGFjuip-J5dDw7sbVHxXA22s-pBO764CivsFt4",
-    "type": "DelegatorOOBI",
-    "serviceEndpoint": "http://keria:3902/oobi/ENro7uf0ePmiK3jdTo2YCdXLqW7z7xoP6qhhBou6gBLe"
-  }]
-}
-```
-
-::: informative Delegator endpoint example explanation
-In this example, the `id` field contains the [[ref: SAID]] of the seal in the
-delegator's [[ref: KEL]] that anchors the delegation commitment, and the
-`serviceEndpoint` provides the [[ref: OOBI]] URL to retrieve the delegator's
-key state so that the delegator's KEL may be searched for the delegation
-seal referred to by the `id` property.
-:::
 
 ### Designated Aliases
 

--- a/spec/body.md
+++ b/spec/body.md
@@ -1142,7 +1142,7 @@ aliases ACDC, the `alsoKnownAs` properties.
    MUST do the following:
     1. The top-level `id` and `controller` property values of the DID document
        MUST replace the `did:web` prefix string with the `did:webs` prefix.
-    1. If authorized by designated alias ACDC, the top-level `alsoKnownAs` property
+    1. The top-level `alsoKnownAs` property
        containing a `did:webs` DID MUST replace that `did:webs` entry with the
        authorized `did:web` DID corresponding to the old `did:web` value from
        the prior `id` and `controller` field values (`did:web` DID).

--- a/spec/header.md
+++ b/spec/header.md
@@ -1,7 +1,7 @@
 ToIP `did:webs` Method Specification
 ==================
 
-**Specification Status**: v0.10.0
+**Specification Status**: v0.10.1
 
 In order to further validate and improve the specification and to
 demonstrate interoperability between multiple implementations of did:webs,


### PR DESCRIPTION
The transformation rules are now clear. The old, convoluted language is removed and replaced with explicit language clarifying what happens when `did:webs` -> `did:web` or `did:web` to `did:webs` transformations occur with explicit call outs to the necessity of designated alias ACDCs when making changes to the `alsoKnownAs` section of the DID documents.

This PR also adds a listing of service endpoint types in the overall Service Endpoint section and reorders the service endpoint list to put the `agent` type last, after delegator OOBI. This reordering matches the most likely occurrence of service endpoint types in the wild.